### PR TITLE
feat!: Deref detection for common types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,16 @@ struct User {
     admin: bool,
 
     /// the user's name
-    #[fieldwork(deref = str)]
     name: String,
 
     /// the user's favorite color, if set
-    #[fieldwork(deref = str)]
     favorite_color: Option<String>,
 
     #[fieldwork(skip)]
     private: (),
 
     /// read-only unique identifier
-    #[fieldwork(deref = "[u8]", opt_in, get)]
+    #[fieldwork(opt_in, get)]
     id: Vec<u8>,
 }
 ```
@@ -82,6 +80,7 @@ This generates all of the following code:
 
 ```rust
 // GENERATED
+
 impl User {
     /**Returns a copy of whether this user is an admin
 

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -1,0 +1,15 @@
+#![allow(dead_code)]
+
+#[derive(fieldwork::Fieldwork, Default)]
+#[fieldwork(get, get_mut, option = false, deref = false)]
+struct User {
+    a: Option<String>,
+    #[fieldwork(option)]
+    b: Option<String>,
+    #[fieldwork(option, deref)]
+    c: Option<String>,
+    #[fieldwork(deref)]
+    d: Option<String>,
+}
+
+fn main() {}

--- a/src/deref_handling.rs
+++ b/src/deref_handling.rs
@@ -1,0 +1,60 @@
+use std::borrow::Cow;
+
+use syn::{GenericArgument, Path, PathArguments, Type, TypePath};
+
+pub(crate) fn auto_deref(ty: &Type) -> Option<Cow<'_, Type>> {
+    let Type::Path(TypePath {
+        path: Path { segments, .. },
+        ..
+    }) = ty
+    else {
+        return None;
+    };
+
+    let last_segment = segments.last()?;
+    if last_segment.ident == "String" {
+        return Some(Cow::Owned(syn::parse_quote!(str)));
+    }
+
+    if last_segment.ident == "Vec" {
+        let PathArguments::AngleBracketed(ref bracketed_args) = last_segment.arguments else {
+            return None;
+        };
+
+        let Some(GenericArgument::Type(inner_type)) = bracketed_args.args.first() else {
+            return None;
+        };
+
+        return Some(Cow::Owned(syn::parse_quote!([#inner_type])));
+    }
+
+    if last_segment.ident == "Box" || last_segment.ident == "Arc" || last_segment.ident == "Rc" {
+        let PathArguments::AngleBracketed(ref bracketed_args) = last_segment.arguments else {
+            return None;
+        };
+
+        let Some(GenericArgument::Type(inner_type)) = bracketed_args.args.first() else {
+            return None;
+        };
+
+        return Some(Cow::Borrowed(inner_type));
+    }
+
+    if last_segment.ident == "Cow" {
+        let PathArguments::AngleBracketed(ref bracketed_args) = last_segment.arguments else {
+            return None;
+        };
+
+        let Some(GenericArgument::Lifetime(_)) = bracketed_args.args.first() else {
+            return None;
+        };
+
+        let Some(GenericArgument::Type(t)) = bracketed_args.args.get(1) else {
+            return None;
+        };
+
+        return Some(Cow::Borrowed(t));
+    }
+
+    None
+}

--- a/src/field_attributes.rs
+++ b/src/field_attributes.rs
@@ -20,6 +20,7 @@ pub(crate) struct FieldAttributes {
     pub(crate) deref: Option<Type>,
     pub(crate) opt_in: bool,
     pub(crate) option_handling: Option<bool>,
+    pub(crate) auto_deref: Option<bool>,
 }
 
 impl FieldAttributes {
@@ -142,6 +143,7 @@ impl FieldAttributes {
             "option" => self.option_handling = Some(value),
             "opt_in" => self.opt_in = value,
             "skip" => self.skip = value,
+            "deref" => self.auto_deref = Some(value),
             other if value => {
                 self.method_attributes.push(FieldMethodAttributes::new(
                     Method::from_str_with_span(other, span)?,

--- a/src/field_method_attributes.rs
+++ b/src/field_method_attributes.rs
@@ -20,6 +20,7 @@ pub(crate) struct FieldMethodAttributes {
     pub(crate) get_copy: Option<bool>,
     pub(crate) deref: Option<Type>,
     pub(crate) option_handling: Option<bool>,
+    pub(crate) auto_deref: Option<bool>,
 }
 
 impl FieldMethodAttributes {
@@ -35,6 +36,7 @@ impl FieldMethodAttributes {
             deref: None,
             skip: false,
             option_handling: None,
+            auto_deref: None,
         }
     }
 
@@ -107,6 +109,7 @@ impl FieldMethodAttributes {
             ("copy", Method::Get) => self.get_copy = Some(value),
             ("skip", _) => self.skip = value,
             ("option", _) => self.option_handling = Some(value),
+            ("deref", _) => self.auto_deref = Some(value),
             _ => return Err(Error::new(span, "not recognized")),
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
+mod deref_handling;
 mod field;
 mod field_attributes;
 mod field_method_attributes;
@@ -40,6 +41,7 @@ pub(crate) use struct_method_attributes::StructMethodAttributes;
 
 const DEFAULT_CHAINABLE_SET: bool = true;
 const DEFAULT_OPTION_HANDLING: bool = true;
+const DEFAULT_AUTO_DEREF: bool = true;
 
 /// see crate-level documentation
 #[proc_macro_derive(Fieldwork, attributes(fieldwork))]

--- a/src/option_handling.rs
+++ b/src/option_handling.rs
@@ -1,37 +1,54 @@
+use std::borrow::Cow;
+
 use syn::{GenericArgument, Path, PathArguments, Type, TypePath, TypeReference};
 
-pub(crate) fn extract_option_type(ty: &Type) -> Option<&Type> {
-    let Type::Path(TypePath {
-        path: Path { segments, .. },
-        ..
-    }) = ty
-    else {
-        return None;
-    };
+pub(crate) fn extract_option_type(ty: Cow<'_, Type>) -> Option<Cow<'_, Type>> {
+    match ty {
+        Cow::Borrowed(Type::Path(TypePath {
+            path: Path { segments, .. },
+            ..
+        })) => {
+            let last_segment = segments.last()?;
+            if last_segment.ident != "Option" {
+                return None;
+            }
 
-    let last_segment = segments.last()?;
-    if last_segment.ident != "Option" {
-        return None;
+            let PathArguments::AngleBracketed(ref bracketed_args) = last_segment.arguments else {
+                return None;
+            };
+
+            let Some(GenericArgument::Type(inner_type)) = bracketed_args.args.first() else {
+                return None;
+            };
+            Some(strip_ref(Cow::Borrowed(inner_type)))
+        }
+
+        Cow::Owned(Type::Path(TypePath {
+            path: Path { segments, .. },
+            ..
+        })) => {
+            let last_segment = segments.last()?;
+            if last_segment.ident != "Option" {
+                return None;
+            }
+
+            let PathArguments::AngleBracketed(ref bracketed_args) = last_segment.arguments else {
+                return None;
+            };
+
+            let Some(GenericArgument::Type(inner_type)) = bracketed_args.args.first() else {
+                return None;
+            };
+            Some(strip_ref(Cow::Owned(inner_type.clone())))
+        }
+        _ => None,
     }
-
-    let PathArguments::AngleBracketed(ref bracketed_args) = last_segment.arguments else {
-        return None;
-    };
-
-    let Some(GenericArgument::Type(inner_type)) = bracketed_args.args.first() else {
-        return None;
-    };
-    Some(strip_ref(inner_type))
 }
 
-pub(crate) fn strip_option_and_ref(ty: &Type) -> &Type {
-    strip_ref(extract_option_type(ty).unwrap_or(ty))
-}
-
-pub(crate) fn strip_ref(ty: &Type) -> &Type {
-    if let Type::Reference(TypeReference { elem, .. }) = &ty {
-        elem
-    } else {
-        ty
+pub(crate) fn strip_ref(ty: Cow<'_, Type>) -> Cow<'_, Type> {
+    match ty {
+        Cow::Borrowed(Type::Reference(TypeReference { elem, .. })) => Cow::Borrowed(elem),
+        Cow::Owned(Type::Reference(TypeReference { elem, .. })) => Cow::Owned(*elem),
+        _ => ty,
     }
 }

--- a/src/resolved.rs
+++ b/src/resolved.rs
@@ -16,7 +16,7 @@ pub(crate) struct Resolved<'a> {
     pub(crate) doc: Option<Cow<'a, str>>,
     pub(crate) get_copy: bool,
     pub(crate) chainable_set: bool,
-    pub(crate) deref_type: Option<&'a Type>,
+    pub(crate) deref_type: Option<Cow<'a, Type>>,
     pub(crate) option_handling: Option<OptionHandling<'a>>,
 }
 

--- a/src/struct_attributes.rs
+++ b/src/struct_attributes.rs
@@ -19,6 +19,7 @@ pub(crate) struct StructAttributes {
     pub(crate) where_clause: Option<WhereClause>,
     pub(crate) opt_in: bool,
     pub(crate) option_handling: Option<bool>,
+    pub(crate) auto_deref: Option<bool>,
 }
 impl StructAttributes {
     pub(crate) fn build(attributes: &[Attribute]) -> syn::Result<Self> {
@@ -107,6 +108,7 @@ impl StructAttributes {
         match lhs {
             "option" => self.option_handling = Some(value),
             "opt_in" => self.opt_in = value,
+            "deref" => self.auto_deref = Some(value),
             other if value => {
                 let method = Method::from_str_with_span(other, span)?;
                 self.include.insert(method);

--- a/src/struct_method_attributes.rs
+++ b/src/struct_method_attributes.rs
@@ -16,6 +16,7 @@ pub(crate) struct StructMethodAttributes {
     pub(crate) doc_template: Option<String>,
     pub(crate) chainable_set: Option<bool>,
     pub(crate) option_handling: Option<bool>,
+    pub(crate) auto_deref: Option<bool>,
 }
 
 impl StructMethodAttributes {
@@ -28,6 +29,7 @@ impl StructMethodAttributes {
             doc_template: None,
             chainable_set: None,
             option_handling: None,
+            auto_deref: None,
         }
     }
 
@@ -88,6 +90,7 @@ impl StructMethodAttributes {
             ("chain", Method::Set) => self.chainable_set = Some(value),
             ("skip", _) => self.skip = value,
             ("option", _) => self.option_handling = Some(value),
+            ("deref", _) => self.auto_deref = Some(value),
             _ => return Err(Error::new(span, "not recognized")),
         }
         Ok(())

--- a/tests/expand/01-basic.expanded.rs
+++ b/tests/expand/01-basic.expanded.rs
@@ -1,68 +1,97 @@
-#[fieldwork(get, set, with, get_mut)]
-struct MyStruct<T> {
-    /// the number
-    number: usize,
-    /// whether something is enabled
-    enabled: bool,
-    /// the generic
-    generic: T,
+#[fieldwork(get, set, get_mut, with)]
+struct User {
+    /// whether this user is an admin
+    ///
+    /// Note that this is distinct from the notion of group administration,
+    /// for historical reasons
+    #[fieldwork(
+        argument = is_admin,
+        get(copy, rename = is_admin),
+        get_mut = is_admin_mut
+    )]
+    admin: bool,
+    /// the user's name
+    name: String,
+    /// the user's favorite color, if set
+    favorite_color: Option<String>,
+    #[fieldwork(skip)]
+    private: (),
+    /// read-only unique identifier
+    #[fieldwork(opt_in, get)]
+    id: Vec<u8>,
 }
-impl<T> MyStruct<T> {
-    ///Borrows the number
-    pub fn number(&self) -> &usize {
-        &self.number
+impl User {
+    /**Returns a copy of whether this user is an admin
+
+Note that this is distinct from the notion of group administration,
+for historical reasons*/
+    pub fn is_admin(&self) -> bool {
+        self.admin
     }
-    ///Mutably borrow the number
-    pub fn number_mut(&mut self) -> &mut usize {
-        &mut self.number
+    /**Mutably borrow whether this user is an admin
+
+Note that this is distinct from the notion of group administration,
+for historical reasons*/
+    pub fn is_admin_mut(&mut self) -> &mut bool {
+        &mut self.admin
     }
-    ///Sets the number, returning `&mut Self` for chaining
-    pub fn set_number(&mut self, number: usize) -> &mut Self {
-        self.number = number;
+    /**Sets whether this user is an admin, returning `&mut Self` for chaining
+
+Note that this is distinct from the notion of group administration,
+for historical reasons*/
+    pub fn set_admin(&mut self, is_admin: bool) -> &mut Self {
+        self.admin = is_admin;
         self
     }
-    ///Owned chainable setter for the number, returning `Self`
+    /**Owned chainable setter for whether this user is an admin, returning `Self`
+
+Note that this is distinct from the notion of group administration,
+for historical reasons*/
     #[must_use]
-    pub fn with_number(mut self, number: usize) -> Self {
-        self.number = number;
+    pub fn with_admin(mut self, is_admin: bool) -> Self {
+        self.admin = is_admin;
         self
     }
-    ///Borrows whether something is enabled
-    pub fn enabled(&self) -> &bool {
-        &self.enabled
+    ///Borrows the user's name
+    pub fn name(&self) -> &str {
+        &*self.name
     }
-    ///Mutably borrow whether something is enabled
-    pub fn enabled_mut(&mut self) -> &mut bool {
-        &mut self.enabled
+    ///Mutably borrow the user's name
+    pub fn name_mut(&mut self) -> &mut str {
+        &mut *self.name
     }
-    ///Sets whether something is enabled, returning `&mut Self` for chaining
-    pub fn set_enabled(&mut self, enabled: bool) -> &mut Self {
-        self.enabled = enabled;
+    ///Sets the user's name, returning `&mut Self` for chaining
+    pub fn set_name(&mut self, name: String) -> &mut Self {
+        self.name = name;
         self
     }
-    ///Owned chainable setter for whether something is enabled, returning `Self`
+    ///Owned chainable setter for the user's name, returning `Self`
     #[must_use]
-    pub fn with_enabled(mut self, enabled: bool) -> Self {
-        self.enabled = enabled;
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
         self
     }
-    ///Borrows the generic
-    pub fn generic(&self) -> &T {
-        &self.generic
+    ///Borrows the user's favorite color, if set
+    pub fn favorite_color(&self) -> Option<&str> {
+        self.favorite_color.as_deref()
     }
-    ///Mutably borrow the generic
-    pub fn generic_mut(&mut self) -> &mut T {
-        &mut self.generic
+    ///Mutably borrow the user's favorite color, if set
+    pub fn favorite_color_mut(&mut self) -> Option<&mut str> {
+        self.favorite_color.as_deref_mut()
     }
-    ///Sets the generic, returning `&mut Self` for chaining
-    pub fn set_generic(&mut self, generic: T) -> &mut Self {
-        self.generic = generic;
+    ///Sets the user's favorite color, if set, returning `&mut Self` for chaining
+    pub fn set_favorite_color(&mut self, favorite_color: Option<String>) -> &mut Self {
+        self.favorite_color = favorite_color;
         self
     }
-    ///Owned chainable setter for the generic, returning `Self`
+    ///Owned chainable setter for the user's favorite color, if set, returning `Self`
     #[must_use]
-    pub fn with_generic(mut self, generic: T) -> Self {
-        self.generic = generic;
+    pub fn with_favorite_color(mut self, favorite_color: Option<String>) -> Self {
+        self.favorite_color = favorite_color;
         self
+    }
+    ///Borrows read-only unique identifier
+    pub fn id(&self) -> &[u8] {
+        &*self.id
     }
 }

--- a/tests/expand/01-basic.rs
+++ b/tests/expand/01-basic.rs
@@ -1,10 +1,27 @@
 #[derive(fieldwork::Fieldwork)]
-#[fieldwork(get, set, with, get_mut)]
-struct MyStruct<T> {
-    /// the number
-    number: usize,
-    /// whether something is enabled
-    enabled: bool,
-    /// the generic
-    generic: T,
+#[fieldwork(get, set, get_mut, with)]
+struct User {
+    /// whether this user is an admin
+    ///
+    /// Note that this is distinct from the notion of group administration,
+    /// for historical reasons
+    #[fieldwork(
+        argument = is_admin,
+        get(copy, rename = is_admin),
+        get_mut = is_admin_mut
+    )]
+    admin: bool,
+
+    /// the user's name
+    name: String,
+
+    /// the user's favorite color, if set
+    favorite_color: Option<String>,
+
+    #[fieldwork(skip)]
+    private: (),
+
+    /// read-only unique identifier
+    #[fieldwork(opt_in, get)]
+    id: Vec<u8>,
 }

--- a/tests/expand/13-deref.expanded.rs
+++ b/tests/expand/13-deref.expanded.rs
@@ -1,64 +1,50 @@
 struct User {
-    /// the user's name
-    #[fieldwork(deref = str, get, set, get_mut)]
-    name: String,
-    #[fieldwork(deref = "[u8]", get, set, get_mut)]
-    arr: Vec<u8>,
+    #[fieldwork(deref = DerefType, get, set, get_mut)]
+    deref_both: OwnedType,
 }
 impl User {
-    ///Borrows the user's name
-    pub fn name(&self) -> &str {
-        &*self.name
+    pub fn deref_both(&self) -> &DerefType {
+        &*self.deref_both
     }
-    ///Mutably borrow the user's name
-    pub fn name_mut(&mut self) -> &mut str {
-        &mut *self.name
+    pub fn deref_both_mut(&mut self) -> &mut DerefType {
+        &mut *self.deref_both
     }
-    ///Sets the user's name, returning `&mut Self` for chaining
-    pub fn set_name(&mut self, name: String) -> &mut Self {
-        self.name = name;
-        self
-    }
-    pub fn arr(&self) -> &[u8] {
-        &*self.arr
-    }
-    pub fn arr_mut(&mut self) -> &mut [u8] {
-        &mut *self.arr
-    }
-    pub fn set_arr(&mut self, arr: Vec<u8>) -> &mut Self {
-        self.arr = arr;
+    pub fn set_deref_both(&mut self, deref_both: OwnedType) -> &mut Self {
+        self.deref_both = deref_both;
         self
     }
 }
 struct OnlyDerefForMethods {
-    /// the user's name
-    #[fieldwork(get(deref = str), set, get_mut)]
-    name: String,
-    #[fieldwork(get, set, get_mut(deref = "[u8]"))]
-    arr: Vec<u8>,
+    #[fieldwork(get(deref = DerefType), set, get_mut)]
+    deref_for_get_only: OwnedType,
+    #[fieldwork(get, set, get_mut(deref = "DerefType"))]
+    deref_for_get_mut_only: OwnedType,
 }
 impl OnlyDerefForMethods {
-    ///Borrows the user's name
-    pub fn name(&self) -> &str {
-        &*self.name
+    pub fn deref_for_get_only(&self) -> &DerefType {
+        &*self.deref_for_get_only
     }
-    ///Mutably borrow the user's name
-    pub fn name_mut(&mut self) -> &mut String {
-        &mut self.name
+    pub fn deref_for_get_only_mut(&mut self) -> &mut OwnedType {
+        &mut self.deref_for_get_only
     }
-    ///Sets the user's name, returning `&mut Self` for chaining
-    pub fn set_name(&mut self, name: String) -> &mut Self {
-        self.name = name;
+    pub fn set_deref_for_get_only(
+        &mut self,
+        deref_for_get_only: OwnedType,
+    ) -> &mut Self {
+        self.deref_for_get_only = deref_for_get_only;
         self
     }
-    pub fn arr(&self) -> &Vec<u8> {
-        &self.arr
+    pub fn deref_for_get_mut_only(&self) -> &OwnedType {
+        &self.deref_for_get_mut_only
     }
-    pub fn arr_mut(&mut self) -> &mut [u8] {
-        &mut *self.arr
+    pub fn deref_for_get_mut_only_mut(&mut self) -> &mut DerefType {
+        &mut *self.deref_for_get_mut_only
     }
-    pub fn set_arr(&mut self, arr: Vec<u8>) -> &mut Self {
-        self.arr = arr;
+    pub fn set_deref_for_get_mut_only(
+        &mut self,
+        deref_for_get_mut_only: OwnedType,
+    ) -> &mut Self {
+        self.deref_for_get_mut_only = deref_for_get_mut_only;
         self
     }
 }

--- a/tests/expand/13-deref.rs
+++ b/tests/expand/13-deref.rs
@@ -1,19 +1,14 @@
 #[derive(fieldwork::Fieldwork)]
 struct User {
-    /// the user's name
-    #[fieldwork(deref = str, get, set, get_mut)]
-    name: String,
-
-    #[fieldwork(deref = "[u8]", get, set, get_mut)]
-    arr: Vec<u8>,
+    #[fieldwork(deref = DerefType, get, set, get_mut)]
+    deref_both: OwnedType,
 }
 
 #[derive(fieldwork::Fieldwork)]
 struct OnlyDerefForMethods {
-    /// the user's name
-    #[fieldwork(get(deref = str), set, get_mut)]
-    name: String,
+    #[fieldwork(get(deref = DerefType), set, get_mut)]
+    deref_for_get_only: OwnedType,
 
-    #[fieldwork(get, set, get_mut(deref = "[u8]"))]
-    arr: Vec<u8>,
+    #[fieldwork(get, set, get_mut(deref = "DerefType"))]
+    deref_for_get_mut_only: OwnedType,
 }

--- a/tests/expand/14-option-detection.expanded.rs
+++ b/tests/expand/14-option-detection.expanded.rs
@@ -67,11 +67,11 @@ impl OptInOption {
     pub fn option_deref_other_style_mut(&mut self) -> Option<&mut str> {
         self.option_deref_other_style.as_deref_mut()
     }
-    pub fn option_detection(&self) -> Option<&String> {
-        self.option_detection.as_ref()
+    pub fn option_detection(&self) -> Option<&str> {
+        self.option_detection.as_deref()
     }
-    pub fn option_detection_mut(&mut self) -> Option<&mut String> {
-        self.option_detection.as_mut()
+    pub fn option_detection_mut(&mut self) -> Option<&mut str> {
+        self.option_detection.as_deref_mut()
     }
     pub fn no_option_detection(&self) -> &Option<()> {
         &self.no_option_detection
@@ -111,11 +111,11 @@ impl OptionOnlyForGet {
     pub fn option_deref_mut(&mut self) -> &mut Option<String> {
         &mut self.option_deref
     }
-    pub fn field_overrides(&self) -> Option<&String> {
-        self.field_overrides.as_ref()
+    pub fn field_overrides(&self) -> Option<&str> {
+        self.field_overrides.as_deref()
     }
-    pub fn field_overrides_mut(&mut self) -> Option<&mut String> {
-        self.field_overrides.as_mut()
+    pub fn field_overrides_mut(&mut self) -> Option<&mut str> {
+        self.field_overrides.as_deref_mut()
     }
     pub fn option_only_for_get(&self) -> Option<&()> {
         self.option_only_for_get.as_ref()
@@ -128,5 +128,41 @@ impl OptionOnlyForGet {
     }
     pub fn option_detection_only_get_mut_mut(&mut self) -> Option<&mut ()> {
         self.option_detection_only_get_mut.as_mut()
+    }
+}
+#[fieldwork(get, get_mut, option = false, deref = false)]
+struct OptionAndDerefInteraction {
+    a: Option<String>,
+    #[fieldwork(option)]
+    b: Option<String>,
+    #[fieldwork(option, deref)]
+    c: Option<String>,
+    #[fieldwork(deref)]
+    d: Option<String>,
+}
+impl OptionAndDerefInteraction {
+    pub fn a(&self) -> &Option<String> {
+        &self.a
+    }
+    pub fn a_mut(&mut self) -> &mut Option<String> {
+        &mut self.a
+    }
+    pub fn b(&self) -> Option<&String> {
+        self.b.as_ref()
+    }
+    pub fn b_mut(&mut self) -> Option<&mut String> {
+        self.b.as_mut()
+    }
+    pub fn c(&self) -> Option<&str> {
+        self.c.as_deref()
+    }
+    pub fn c_mut(&mut self) -> Option<&mut str> {
+        self.c.as_deref_mut()
+    }
+    pub fn d(&self) -> &Option<String> {
+        &self.d
+    }
+    pub fn d_mut(&mut self) -> &mut Option<String> {
+        &mut self.d
     }
 }

--- a/tests/expand/14-option-detection.rs
+++ b/tests/expand/14-option-detection.rs
@@ -51,3 +51,15 @@ struct OptionOnlyForGet {
     #[fieldwork(get_mut(option), get(option = false))]
     option_detection_only_get_mut: Option<()>,
 }
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, get_mut, option = false, deref = false)]
+struct OptionAndDerefInteraction {
+    a: Option<String>,
+    #[fieldwork(option)]
+    b: Option<String>,
+    #[fieldwork(option, deref)]
+    c: Option<String>,
+    #[fieldwork(deref)]
+    d: Option<String>, // remains Option<String>
+}

--- a/tests/expand/15-auto-deref.expanded.rs
+++ b/tests/expand/15-auto-deref.expanded.rs
@@ -1,0 +1,212 @@
+#[fieldwork(get, get_mut)]
+struct Detection<'a, T> {
+    string: String,
+    vec: Vec<u8>,
+    boxed: Box<T>,
+    boxed_dyn: Box<dyn Display>,
+    arc: std::sync::Arc<T>,
+    rc: std::rc::Rc<T>,
+    cow: Cow<'a, T>,
+}
+impl<'a, T> Detection<'a, T> {
+    pub fn string(&self) -> &str {
+        &*self.string
+    }
+    pub fn string_mut(&mut self) -> &mut str {
+        &mut *self.string
+    }
+    pub fn vec(&self) -> &[u8] {
+        &*self.vec
+    }
+    pub fn vec_mut(&mut self) -> &mut [u8] {
+        &mut *self.vec
+    }
+    pub fn boxed(&self) -> &T {
+        &*self.boxed
+    }
+    pub fn boxed_mut(&mut self) -> &mut T {
+        &mut *self.boxed
+    }
+    pub fn boxed_dyn(&self) -> &dyn Display {
+        &*self.boxed_dyn
+    }
+    pub fn boxed_dyn_mut(&mut self) -> &mut dyn Display {
+        &mut *self.boxed_dyn
+    }
+    pub fn arc(&self) -> &T {
+        &*self.arc
+    }
+    pub fn arc_mut(&mut self) -> &mut T {
+        &mut *self.arc
+    }
+    pub fn rc(&self) -> &T {
+        &*self.rc
+    }
+    pub fn rc_mut(&mut self) -> &mut T {
+        &mut *self.rc
+    }
+    pub fn cow(&self) -> &T {
+        &*self.cow
+    }
+    pub fn cow_mut(&mut self) -> &mut T {
+        &mut *self.cow
+    }
+}
+#[fieldwork(get, get_mut, deref = false)]
+struct DerefFalseAtStruct {
+    baseline_no_auto_deref: String,
+    #[fieldwork(deref = true)]
+    field_deref_true: Vec<u8>,
+}
+impl DerefFalseAtStruct {
+    pub fn baseline_no_auto_deref(&self) -> &String {
+        &self.baseline_no_auto_deref
+    }
+    pub fn baseline_no_auto_deref_mut(&mut self) -> &mut String {
+        &mut self.baseline_no_auto_deref
+    }
+    pub fn field_deref_true(&self) -> &[u8] {
+        &*self.field_deref_true
+    }
+    pub fn field_deref_true_mut(&mut self) -> &mut [u8] {
+        &mut *self.field_deref_true
+    }
+}
+#[fieldwork(get, get_mut(deref = false))]
+struct DerefFalseForGetMut {
+    baseline_deref_for_get_but_not_for_get_mut: Vec<()>,
+    #[fieldwork(get_mut(deref))]
+    deref_both: String,
+    #[fieldwork(deref = true)]
+    also_deref_both: Vec<u8>,
+}
+impl DerefFalseForGetMut {
+    pub fn baseline_deref_for_get_but_not_for_get_mut(&self) -> &[()] {
+        &*self.baseline_deref_for_get_but_not_for_get_mut
+    }
+    pub fn baseline_deref_for_get_but_not_for_get_mut_mut(&mut self) -> &mut Vec<()> {
+        &mut self.baseline_deref_for_get_but_not_for_get_mut
+    }
+    pub fn deref_both(&self) -> &str {
+        &*self.deref_both
+    }
+    pub fn deref_both_mut(&mut self) -> &mut str {
+        &mut *self.deref_both
+    }
+    pub fn also_deref_both(&self) -> &[u8] {
+        &*self.also_deref_both
+    }
+    pub fn also_deref_both_mut(&mut self) -> &mut [u8] {
+        &mut *self.also_deref_both
+    }
+}
+#[fieldwork(get, get_mut, deref = false)]
+struct SpecifyingTypeStillWorksWithDerefFalse {
+    baseline_no_auto_deref: Vec<()>,
+    #[fieldwork(get(deref = DerefType))]
+    deref_get_to_specified_type: OwnedType,
+    #[fieldwork(deref = DerefType)]
+    deref_to_specified_type: OwnedType,
+}
+impl SpecifyingTypeStillWorksWithDerefFalse {
+    pub fn baseline_no_auto_deref(&self) -> &Vec<()> {
+        &self.baseline_no_auto_deref
+    }
+    pub fn baseline_no_auto_deref_mut(&mut self) -> &mut Vec<()> {
+        &mut self.baseline_no_auto_deref
+    }
+    pub fn deref_get_to_specified_type(&self) -> &DerefType {
+        &*self.deref_get_to_specified_type
+    }
+    pub fn deref_get_to_specified_type_mut(&mut self) -> &mut OwnedType {
+        &mut self.deref_get_to_specified_type
+    }
+    pub fn deref_to_specified_type(&self) -> &DerefType {
+        &*self.deref_to_specified_type
+    }
+    pub fn deref_to_specified_type_mut(&mut self) -> &mut DerefType {
+        &mut *self.deref_to_specified_type
+    }
+}
+#[fieldwork(get, get_mut, deref = false)]
+struct SpecifyingTypeStillWorksWithDerefFalse {
+    baseline_no_auto_deref: Vec<()>,
+    #[fieldwork(get(deref = DerefType))]
+    deref_get_to_specified_type: OwnedType,
+    #[fieldwork(deref = DerefType)]
+    deref_to_specified_type: OwnedType,
+}
+impl SpecifyingTypeStillWorksWithDerefFalse {
+    pub fn baseline_no_auto_deref(&self) -> &Vec<()> {
+        &self.baseline_no_auto_deref
+    }
+    pub fn baseline_no_auto_deref_mut(&mut self) -> &mut Vec<()> {
+        &mut self.baseline_no_auto_deref
+    }
+    pub fn deref_get_to_specified_type(&self) -> &DerefType {
+        &*self.deref_get_to_specified_type
+    }
+    pub fn deref_get_to_specified_type_mut(&mut self) -> &mut OwnedType {
+        &mut self.deref_get_to_specified_type
+    }
+    pub fn deref_to_specified_type(&self) -> &DerefType {
+        &*self.deref_to_specified_type
+    }
+    pub fn deref_to_specified_type_mut(&mut self) -> &mut DerefType {
+        &mut *self.deref_to_specified_type
+    }
+}
+#[fieldwork(get, get_mut)]
+struct OptionDeref<'a, T> {
+    string: Option<String>,
+    vec: Option<Vec<u8>>,
+    boxed: Option<Box<T>>,
+    boxed_dyn: Option<Box<dyn Display>>,
+    arc: Option<std::sync::Arc<T>>,
+    rc: Option<std::rc::Rc<T>>,
+    cow: Option<Cow<'a, T>>,
+}
+impl<'a, T> OptionDeref<'a, T> {
+    pub fn string(&self) -> Option<&str> {
+        self.string.as_deref()
+    }
+    pub fn string_mut(&mut self) -> Option<&mut str> {
+        self.string.as_deref_mut()
+    }
+    pub fn vec(&self) -> Option<&[u8]> {
+        self.vec.as_deref()
+    }
+    pub fn vec_mut(&mut self) -> Option<&mut [u8]> {
+        self.vec.as_deref_mut()
+    }
+    pub fn boxed(&self) -> Option<&T> {
+        self.boxed.as_deref()
+    }
+    pub fn boxed_mut(&mut self) -> Option<&mut T> {
+        self.boxed.as_deref_mut()
+    }
+    pub fn boxed_dyn(&self) -> Option<&dyn Display> {
+        self.boxed_dyn.as_deref()
+    }
+    pub fn boxed_dyn_mut(&mut self) -> Option<&mut dyn Display> {
+        self.boxed_dyn.as_deref_mut()
+    }
+    pub fn arc(&self) -> Option<&T> {
+        self.arc.as_deref()
+    }
+    pub fn arc_mut(&mut self) -> Option<&mut T> {
+        self.arc.as_deref_mut()
+    }
+    pub fn rc(&self) -> Option<&T> {
+        self.rc.as_deref()
+    }
+    pub fn rc_mut(&mut self) -> Option<&mut T> {
+        self.rc.as_deref_mut()
+    }
+    pub fn cow(&self) -> Option<&T> {
+        self.cow.as_deref()
+    }
+    pub fn cow_mut(&mut self) -> Option<&mut T> {
+        self.cow.as_deref_mut()
+    }
+}

--- a/tests/expand/15-auto-deref.rs
+++ b/tests/expand/15-auto-deref.rs
@@ -1,0 +1,68 @@
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, get_mut)]
+struct Detection<'a, T> {
+    string: String,
+    vec: Vec<u8>,
+    boxed: Box<T>,
+    boxed_dyn: Box<dyn Display>,
+    arc: std::sync::Arc<T>,
+    rc: std::rc::Rc<T>,
+    cow: Cow<'a, T>,
+}
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, get_mut, deref = false)]
+struct DerefFalseAtStruct {
+    baseline_no_auto_deref: String,
+
+    #[fieldwork(deref = true)]
+    field_deref_true: Vec<u8>,
+}
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, get_mut(deref = false))]
+struct DerefFalseForGetMut {
+    baseline_deref_for_get_but_not_for_get_mut: Vec<()>,
+
+    #[fieldwork(get_mut(deref))]
+    deref_both: String,
+
+    #[fieldwork(deref = true)]
+    also_deref_both: Vec<u8>,
+}
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, get_mut, deref = false)]
+struct SpecifyingTypeStillWorksWithDerefFalse {
+    baseline_no_auto_deref: Vec<()>,
+
+    #[fieldwork(get(deref = DerefType))]
+    deref_get_to_specified_type: OwnedType,
+
+    #[fieldwork(deref = DerefType)]
+    deref_to_specified_type: OwnedType,
+}
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, get_mut, deref = false)]
+struct SpecifyingTypeStillWorksWithDerefFalse {
+    baseline_no_auto_deref: Vec<()>,
+
+    #[fieldwork(get(deref = DerefType))]
+    deref_get_to_specified_type: OwnedType,
+
+    #[fieldwork(deref = DerefType)]
+    deref_to_specified_type: OwnedType,
+}
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, get_mut)]
+struct OptionDeref<'a, T> {
+    string: Option<String>,
+    vec: Option<Vec<u8>>,
+    boxed: Option<Box<T>>,
+    boxed_dyn: Option<Box<dyn Display>>,
+    arc: Option<std::sync::Arc<T>>,
+    rc: Option<std::rc::Rc<T>>,
+    cow: Option<Cow<'a, T>>,
+}


### PR DESCRIPTION
This PR adds support for auto‐detection of common dereferenceable types (e.g. String, Vec, Box, Arc, Rc, Cow) and refines the handling of Options using auto‐deref, with corresponding updates to tests, docs, and core modules. Key changes include:

* Introduction of an auto_deref configuration flag and constant (DEFAULT_AUTO_DEREF) across various attribute and query modules.
* Updates to getter/setter generation logic to correctly apply dereference, including new syntax handling.
* Documentation updates (docs.md and README.md) that clarify the deref detection behavior.
