### PR TITLE
fix: add missing support for specifying a custom deref type within an…

### DIFF
--- a/src/option_handling.rs
+++ b/src/option_handling.rs
@@ -1,40 +1,32 @@
-use std::borrow::Cow;
-
 use syn::{GenericArgument, Path, PathArguments, Type, TypePath, TypeReference};
 
 pub(crate) fn extract_option_type(ty: &Type) -> Option<&Type> {
-    match ty {
-        Type::Path(TypePath {
-            path: Path { segments, .. },
-            ..
-        }) => {
-            let last_segment = segments.last()?;
-            if last_segment.ident != "Option" {
-                return None;
-            }
+    let Type::Path(TypePath {
+        path: Path { segments, .. },
+        ..
+    }) = ty
+    else {
+        return None;
+    };
 
-            let PathArguments::AngleBracketed(ref bracketed_args) = last_segment.arguments else {
-                return None;
-            };
-
-            let Some(GenericArgument::Type(inner_type)) = bracketed_args.args.first() else {
-                return None;
-            };
-            let Cow::Borrowed(b) = strip_ref(Cow::Borrowed(inner_type)) else {
-                return None;
-            };
-
-            return Some(b);
-        }
-
-        _ => None,
+    let last_segment = segments.last()?;
+    if last_segment.ident != "Option" {
+        return None;
     }
+
+    let PathArguments::AngleBracketed(ref bracketed_args) = last_segment.arguments else {
+        return None;
+    };
+
+    let Some(GenericArgument::Type(inner_type)) = bracketed_args.args.first() else {
+        return None;
+    };
+    Some(strip_ref(inner_type))
 }
 
-pub(crate) fn strip_ref(ty: Cow<'_, Type>) -> Cow<'_, Type> {
+pub(crate) fn strip_ref(ty: &Type) -> &Type {
     match ty {
-        Cow::Borrowed(Type::Reference(TypeReference { elem, .. })) => Cow::Borrowed(elem),
-        Cow::Owned(Type::Reference(TypeReference { elem, .. })) => Cow::Owned(*elem),
+        Type::Reference(TypeReference { elem, .. }) => elem,
         _ => ty,
     }
 }

--- a/tests/expand/14-option-detection.expanded.rs
+++ b/tests/expand/14-option-detection.expanded.rs
@@ -17,11 +17,11 @@ impl OptionBehavior {
     pub fn option_deref_mut(&mut self) -> Option<&mut str> {
         self.option_deref.as_deref_mut()
     }
-    pub fn option_deref_other_style(&self) -> Option<&str> {
-        self.option_deref_other_style.as_deref()
+    pub fn option_deref_other_style(&self) -> &str {
+        &*self.option_deref_other_style
     }
-    pub fn option_deref_other_style_mut(&mut self) -> Option<&mut str> {
-        self.option_deref_other_style.as_deref_mut()
+    pub fn option_deref_other_style_mut(&mut self) -> &mut str {
+        &mut *self.option_deref_other_style
     }
     pub fn no_option_detection(&self) -> &Option<String> {
         &self.no_option_detection
@@ -61,11 +61,11 @@ impl OptInOption {
     pub fn option_deref_mut(&mut self) -> Option<&mut str> {
         self.option_deref.as_deref_mut()
     }
-    pub fn option_deref_other_style(&self) -> Option<&str> {
-        self.option_deref_other_style.as_deref()
+    pub fn option_deref_other_style(&self) -> &str {
+        &*self.option_deref_other_style
     }
-    pub fn option_deref_other_style_mut(&mut self) -> Option<&mut str> {
-        self.option_deref_other_style.as_deref_mut()
+    pub fn option_deref_other_style_mut(&mut self) -> &mut str {
+        &mut *self.option_deref_other_style
     }
     pub fn option_detection(&self) -> Option<&str> {
         self.option_detection.as_deref()
@@ -105,8 +105,8 @@ impl OptionOnlyForGet {
     pub fn no_option_detection_mut(&mut self) -> &mut Option<()> {
         &mut self.no_option_detection
     }
-    pub fn option_deref(&self) -> Option<&str> {
-        self.option_deref.as_deref()
+    pub fn option_deref(&self) -> &str {
+        &*self.option_deref
     }
     pub fn option_deref_mut(&mut self) -> &mut Option<String> {
         &mut self.option_deref
@@ -139,6 +139,8 @@ struct OptionAndDerefInteraction {
     c: Option<String>,
     #[fieldwork(deref)]
     d: Option<String>,
+    #[fieldwork(option, deref = "Option<&CustomDeref>")]
+    e: Option<CustomOwned>,
 }
 impl OptionAndDerefInteraction {
     pub fn a(&self) -> &Option<String> {
@@ -164,5 +166,11 @@ impl OptionAndDerefInteraction {
     }
     pub fn d_mut(&mut self) -> &mut Option<String> {
         &mut self.d
+    }
+    pub fn e(&self) -> Option<&CustomDeref> {
+        self.e.as_deref()
+    }
+    pub fn e_mut(&mut self) -> Option<&mut CustomDeref> {
+        self.e.as_deref_mut()
     }
 }

--- a/tests/expand/14-option-detection.rs
+++ b/tests/expand/14-option-detection.rs
@@ -62,4 +62,6 @@ struct OptionAndDerefInteraction {
     c: Option<String>,
     #[fieldwork(deref)]
     d: Option<String>, // remains Option<String>
+    #[fieldwork(option, deref = "Option<&CustomDeref>")]
+    e: Option<CustomOwned>,
 }


### PR DESCRIPTION
… option.

also remove unnecessary Cow codepaths in option handling — it's never owned