### PR TITLE
fix: allow specifying `copy` at the field configuration level

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -73,6 +73,7 @@ impl<'a> Query<'a> {
         if let Some(field_copy) = self
             .field_method_attributes
             .and_then(|fma| fma.common_settings.get_copy)
+            .or(self.field.attributes.common_settings.get_copy)
         {
             return field_copy;
         }

--- a/tests/expand/11-copy.expanded.rs
+++ b/tests/expand/11-copy.expanded.rs
@@ -112,3 +112,43 @@ impl CopyInteractsWithDeref {
         *self.arc_usize
     }
 }
+#[fieldwork(get)]
+struct AllowSpecifyingCopyAtFieldAttribute<T: Copy> {
+    #[fieldwork(copy)]
+    generic: T,
+    #[fieldwork(copy = true)]
+    another: (T, T),
+}
+impl<T: Copy> AllowSpecifyingCopyAtFieldAttribute<T> {
+    pub fn generic(&self) -> T {
+        self.generic
+    }
+    pub fn another(&self) -> (T, T) {
+        self.another
+    }
+}
+#[fieldwork(get)]
+struct AllowSpecifyingCopyFalseAtFieldAttribute<T: Copy> {
+    #[fieldwork(copy = false)]
+    usize: usize,
+}
+impl<T: Copy> AllowSpecifyingCopyFalseAtFieldAttribute<T> {
+    pub fn usize(&self) -> &usize {
+        &self.usize
+    }
+}
+#[fieldwork(get, copy = false)]
+struct AllowOptingBackInAtFieldAttribute<T: Copy> {
+    #[fieldwork(copy = true)]
+    usize: usize,
+    #[field(copy)]
+    generic: T,
+}
+impl<T: Copy> AllowOptingBackInAtFieldAttribute<T> {
+    pub fn usize(&self) -> usize {
+        self.usize
+    }
+    pub fn generic(&self) -> T {
+        self.generic
+    }
+}

--- a/tests/expand/11-copy.rs
+++ b/tests/expand/11-copy.rs
@@ -47,3 +47,30 @@ struct CopyInteractsWithDeref {
     box_bool: Box<bool>,
     arc_usize: Arc<usize>,
 }
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get)]
+struct AllowSpecifyingCopyAtFieldAttribute<T: Copy> {
+    #[fieldwork(copy)]
+    generic: T,
+
+    #[fieldwork(copy = true)]
+    another: (T, T),
+}
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get)]
+struct AllowSpecifyingCopyFalseAtFieldAttribute<T: Copy> {
+    #[fieldwork(copy = false)]
+    usize: usize,
+}
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, copy = false)]
+struct AllowOptingBackInAtFieldAttribute<T: Copy> {
+    #[fieldwork(copy = true)]
+    usize: usize,
+
+    #[field(copy)]
+    generic: T,
+}

--- a/tests/expand/19-tuple-structs.expanded.rs
+++ b/tests/expand/19-tuple-structs.expanded.rs
@@ -57,8 +57,8 @@ impl Rgb {
 #[fieldwork(get, set, with, get_mut, option_set_some)]
 struct Color(#[fieldwork(name = rgb, copy)] Rgb, #[fieldwork(name = alpha)] Option<u8>);
 impl Color {
-    pub fn rgb(&self) -> &Rgb {
-        &self.0
+    pub fn rgb(&self) -> Rgb {
+        self.0
     }
     pub fn rgb_mut(&mut self) -> &mut Rgb {
         &mut self.0


### PR DESCRIPTION
previously, this silently nooped