### PR TITLE
fix: correctly coerce arrays to slices

### DIFF
--- a/src/deref_handling.rs
+++ b/src/deref_handling.rs
@@ -1,7 +1,7 @@
 use proc_macro2::Span;
 use syn::{
-    GenericArgument, Path, PathArguments, Type, TypeArray, TypePath, TypeReference,
-    TypeTraitObject, parse_quote_spanned,
+    GenericArgument, Path, PathArguments, Type, TypePath, TypeReference, TypeTraitObject,
+    parse_quote_spanned,
 };
 
 use crate::Method;
@@ -36,7 +36,6 @@ pub(crate) fn auto_deref_inner(ty: &Type, method: Method, span: Span) -> Option<
             path: Path { segments, .. },
             ..
         }) => segments,
-        Type::Array(TypeArray { elem, .. }) => return Some(parse_quote_spanned!(span => [#elem])),
         _ => {
             return None;
         }

--- a/src/option_handling.rs
+++ b/src/option_handling.rs
@@ -25,6 +25,31 @@ pub(crate) fn extract_option_type(ty: &Type) -> Option<&Type> {
     Some(inner_type)
 }
 
+pub(crate) fn option_type_mut(ty: &mut Type) -> Option<&mut Type> {
+    let Type::Path(TypePath {
+        path: Path { segments, .. },
+        ..
+    }) = ty
+    else {
+        return None;
+    };
+
+    let last_segment = segments.last_mut()?;
+    if last_segment.ident != "Option" {
+        return None;
+    }
+
+    let PathArguments::AngleBracketed(bracketed_args) = &mut last_segment.arguments else {
+        return None;
+    };
+
+    let Some(GenericArgument::Type(inner_type)) = bracketed_args.args.first_mut() else {
+        return None;
+    };
+
+    Some(inner_type)
+}
+
 pub(crate) fn strip_ref(ty: &Type) -> &Type {
     ref_inner(ty).unwrap_or(ty)
 }
@@ -32,6 +57,15 @@ pub(crate) fn strip_ref(ty: &Type) -> &Type {
 pub(crate) fn ref_inner(ty: &Type) -> Option<&Type> {
     match ty {
         Type::Reference(TypeReference { elem, .. }) => Some(elem),
+        _ => None,
+    }
+}
+
+pub(crate) fn ref_inner_mut(ty: &mut Type) -> Option<(&mut Type, bool)> {
+    match ty {
+        Type::Reference(TypeReference {
+            elem, mutability, ..
+        }) => Some((elem, mutability.is_some())),
         _ => None,
     }
 }

--- a/tests/expand/15-auto-deref.expanded.rs
+++ b/tests/expand/15-auto-deref.expanded.rs
@@ -67,10 +67,10 @@ impl<'a, T> Detection<'a, T> {
         &mut *self.os_string
     }
     pub fn arr(&self) -> &[u8] {
-        &*self.arr
+        &self.arr[..]
     }
     pub fn arr_mut(&mut self) -> &mut [u8] {
-        &mut *self.arr
+        &mut self.arr[..]
     }
 }
 #[fieldwork(get, get_mut, deref = false)]
@@ -246,10 +246,10 @@ impl<'a, T> OptionDeref<'a, T> {
         self.os_string.as_deref_mut()
     }
     pub fn arr(&self) -> Option<&[u8]> {
-        self.arr.as_deref()
+        self.arr.as_ref().map(|arr| &arr[..])
     }
     pub fn arr_mut(&mut self) -> Option<&mut [u8]> {
-        self.arr.as_deref_mut()
+        self.arr.as_mut().map(|arr| &mut arr[..])
     }
 }
 #[fieldwork(get, get_mut)]

--- a/tests/expand/22-arrays.expanded.rs
+++ b/tests/expand/22-arrays.expanded.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+#[fieldwork(get, get_mut)]
+struct DebugStruct {
+    array: [u8; 10],
+    box_array: Box<[u8; 10]>,
+    arc_box_array: Arc<Box<[u8; 10]>>,
+    option_array: Option<[u8; 10]>,
+    option_box_array: Option<Box<[u8; 10]>>,
+    option_arc_box_array: Option<Arc<Box<[u8; 10]>>>,
+}
+impl DebugStruct {
+    pub fn array(&self) -> &[u8] {
+        &self.array[..]
+    }
+    pub fn array_mut(&mut self) -> &mut [u8] {
+        &mut self.array[..]
+    }
+    pub fn box_array(&self) -> &[u8] {
+        &self.box_array[..]
+    }
+    pub fn box_array_mut(&mut self) -> &mut [u8] {
+        &mut self.box_array[..]
+    }
+    pub fn arc_box_array(&self) -> &[u8] {
+        &self.arc_box_array[..]
+    }
+    pub fn arc_box_array_mut(&mut self) -> &mut Arc<Box<[u8; 10]>> {
+        &mut self.arc_box_array
+    }
+    pub fn option_array(&self) -> Option<&[u8]> {
+        self.option_array.as_ref().map(|option_array| &option_array[..])
+    }
+    pub fn option_array_mut(&mut self) -> Option<&mut [u8]> {
+        self.option_array.as_mut().map(|option_array| &mut option_array[..])
+    }
+    pub fn option_box_array(&self) -> Option<&[u8]> {
+        self.option_box_array.as_ref().map(|option_box_array| &option_box_array[..])
+    }
+    pub fn option_box_array_mut(&mut self) -> Option<&mut [u8]> {
+        self.option_box_array.as_mut().map(|option_box_array| &mut option_box_array[..])
+    }
+    pub fn option_arc_box_array(&self) -> Option<&[u8]> {
+        self.option_arc_box_array
+            .as_ref()
+            .map(|option_arc_box_array| &option_arc_box_array[..])
+    }
+    pub fn option_arc_box_array_mut(&mut self) -> Option<&mut Arc<Box<[u8; 10]>>> {
+        self.option_arc_box_array.as_mut()
+    }
+}

--- a/tests/expand/22-arrays.rs
+++ b/tests/expand/22-arrays.rs
@@ -1,0 +1,12 @@
+use std::sync::Arc;
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, get_mut)]
+struct DebugStruct {
+    array: [u8; 10],
+    box_array: Box<[u8; 10]>,
+    arc_box_array: Arc<Box<[u8; 10]>>,
+    option_array: Option<[u8; 10]>,
+    option_box_array: Option<Box<[u8; 10]>>,
+    option_arc_box_array: Option<Arc<Box<[u8; 10]>>>,
+}


### PR DESCRIPTION
Apparently [T;N] isn't Deref<Item = [T]>, so we need to use coersion instead of dereferencing