### PR TITLE
fix: use `where` bounds on structs and enums

### DIFF
--- a/fieldwork-derive/src/enum.rs
+++ b/fieldwork-derive/src/enum.rs
@@ -64,7 +64,12 @@ impl Parse for Enum {
             .collect::<syn::Result<Vec<_>>>()?;
 
         let mut generics = input.generics.clone();
-        generics.where_clause = attributes.where_clause.take();
+        if let Some(attr_where) = attributes.where_clause.take() {
+            generics
+                .make_where_clause()
+                .predicates
+                .extend(attr_where.predicates);
+        }
 
         Ok(Self {
             ident,

--- a/fieldwork-derive/src/struct.rs
+++ b/fieldwork-derive/src/struct.rs
@@ -34,7 +34,12 @@ impl Parse for Struct {
             .collect::<syn::Result<Vec<_>>>()?;
 
         let mut generics = input.generics.clone();
-        generics.where_clause = attributes.where_clause.take();
+        if let Some(attr_where) = attributes.where_clause.take() {
+            generics
+                .make_where_clause()
+                .predicates
+                .extend(attr_where.predicates);
+        }
 
         Ok(Self {
             ident,

--- a/tests/expand/expand_27_where_bounds.expanded.rs
+++ b/tests/expand/expand_27_where_bounds.expanded.rs
@@ -1,0 +1,120 @@
+/// Struct with a where clause (the basic case from issue #105)
+#[fieldwork(get, set, with)]
+struct MyStruct<T>
+where
+    T: Clone,
+{
+    field: T,
+}
+impl<T> MyStruct<T>
+where
+    T: Clone,
+{
+    pub fn field(&self) -> &T {
+        &self.field
+    }
+    pub fn set_field(&mut self, field: T) -> &mut Self {
+        self.field = field;
+        self
+    }
+    #[must_use]
+    pub fn with_field(mut self, field: T) -> Self {
+        self.field = field;
+        self
+    }
+}
+/// Enum with a where clause
+#[fieldwork(get, set)]
+enum Container<T>
+where
+    T: Clone,
+{
+    Filled { value: T, label: String },
+    Empty { label: String },
+}
+impl<T> Container<T>
+where
+    T: Clone,
+{
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Filled { label, .. } | Self::Empty { label, .. } => &**label,
+        }
+    }
+    pub fn set_label(&mut self, label: String) -> &mut Self {
+        match self {
+            Self::Filled { label: label_binding, .. } => {
+                *label_binding = label;
+            }
+            Self::Empty { label: label_binding, .. } => {
+                *label_binding = label;
+            }
+        }
+        self
+    }
+    pub fn value(&self) -> Option<&T> {
+        match self {
+            Self::Filled { value, .. } => Some(value),
+            _ => None,
+        }
+    }
+}
+/// Struct with both inline bounds and a where clause
+#[fieldwork(get, with)]
+struct Mixed<T: std::fmt::Debug, U>
+where
+    U: Clone,
+{
+    debug_field: T,
+    clone_field: U,
+}
+impl<T: std::fmt::Debug, U> Mixed<T, U>
+where
+    U: Clone,
+{
+    pub fn debug_field(&self) -> &T {
+        &self.debug_field
+    }
+    #[must_use]
+    pub fn with_debug_field(mut self, debug_field: T) -> Self {
+        self.debug_field = debug_field;
+        self
+    }
+    pub fn clone_field(&self) -> &U {
+        &self.clone_field
+    }
+    #[must_use]
+    pub fn with_clone_field(mut self, clone_field: U) -> Self {
+        self.clone_field = clone_field;
+        self
+    }
+}
+/// Struct with both #[fieldwork(bounds = "...")] and a struct-level where clause — predicates merged
+#[fieldwork(get, set, bounds = "U: std::fmt::Display")]
+struct WithExplicitBounds<T, U>
+where
+    T: Clone,
+{
+    cloneable: T,
+    displayable: U,
+}
+impl<T, U> WithExplicitBounds<T, U>
+where
+    T: Clone,
+    U: std::fmt::Display,
+{
+    pub fn cloneable(&self) -> &T {
+        &self.cloneable
+    }
+    pub fn set_cloneable(&mut self, cloneable: T) -> &mut Self {
+        self.cloneable = cloneable;
+        self
+    }
+    pub fn displayable(&self) -> &U {
+        &self.displayable
+    }
+    pub fn set_displayable(&mut self, displayable: U) -> &mut Self {
+        self.displayable = displayable;
+        self
+    }
+}

--- a/tests/expand/expand_27_where_bounds.rs
+++ b/tests/expand/expand_27_where_bounds.rs
@@ -1,0 +1,42 @@
+/// Struct with a where clause (the basic case from issue #105)
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, set, with)]
+struct MyStruct<T>
+where
+    T: Clone,
+{
+    field: T,
+}
+
+/// Enum with a where clause
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, set)]
+enum Container<T>
+where
+    T: Clone,
+{
+    Filled { value: T, label: String },
+    Empty { label: String },
+}
+
+/// Struct with both inline bounds and a where clause
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, with)]
+struct Mixed<T: std::fmt::Debug, U>
+where
+    U: Clone,
+{
+    debug_field: T,
+    clone_field: U,
+}
+
+/// Struct with both #[fieldwork(bounds = "...")] and a struct-level where clause — predicates merged
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(get, set, bounds = "U: std::fmt::Display")]
+struct WithExplicitBounds<T, U>
+where
+    T: Clone,
+{
+    cloneable: T,
+    displayable: U,
+}

--- a/tests/expand/mod.rs
+++ b/tests/expand/mod.rs
@@ -25,3 +25,4 @@ mod expand_23_take;
 mod expand_24_into_field;
 mod expand_25_enum_basic;
 mod expand_26_enum_field_config;
+mod expand_27_where_bounds;


### PR DESCRIPTION
closes: #105